### PR TITLE
feat: sidebar-event-propagation  #1279 

### DIFF
--- a/projects/ion/src/lib/core/types/sidebar.ts
+++ b/projects/ion/src/lib/core/types/sidebar.ts
@@ -6,7 +6,7 @@ export interface Item {
   icon: IconType;
   selected?: boolean;
   disabled?: boolean;
-  action?: () => void;
+  action?: (event?: MouseEvent) => void;
 }
 
 export interface IonSidebarProps {

--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.html
@@ -25,7 +25,7 @@
       [shrinkMode]="shrinkMode"
       [sidebarClosed]="sidebarClosed"
       [inGroup]="true"
-      (atClick)="itemSelected(i)"
+      (atClick)="itemSelected(i, $event)"
     ></ion-sidebar-item>
   </ul>
 </section>

--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.ts
@@ -23,7 +23,7 @@ export class IonSidebarGroupComponent implements OnChanges {
   @Input() haveGroupAction = false;
   @Input() shrinkMode = false;
   @Input() sidebarClosed = true;
-  @Output() atClick = new EventEmitter();
+  @Output() atClick = new EventEmitter<MouseEvent>();
   @Output() atGroupClick = new EventEmitter();
 
   public closed = true;
@@ -42,10 +42,10 @@ export class IonSidebarGroupComponent implements OnChanges {
     this.closed = !this.closed;
   }
 
-  public itemSelected(itemIndex: number): void {
+  public itemSelected(itemIndex: number, event: MouseEvent): void {
     this.selected = true;
-    selectItemByIndex(this.items, itemIndex);
-    this.atClick.emit();
+    selectItemByIndex(this.items, itemIndex, event);
+    this.atClick.emit(event);
   }
 
   public groupSelected(): void {

--- a/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.html
@@ -8,7 +8,7 @@
   [class.ion-sidebar-item--shrunk]="shrinkMode && sidebarClosed"
   [class.ion-sidebar-subitem]="inGroup && sidebarClosed"
   [disabled]="disabled"
-  (click)="selectItem()"
+  (click)="selectItem($event)"
 >
   <div>
     <ion-icon class="ion-sidebar-item__icon" [type]="icon"></ion-icon>

--- a/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.ts
@@ -15,10 +15,10 @@ export class IonSidebarItemComponent {
   @Input() shrinkMode = false;
   @Input() sidebarClosed = true;
   @Input() inGroup = false;
-  @Output() atClick = new EventEmitter();
+  @Output() atClick = new EventEmitter<MouseEvent>();
 
-  public selectItem(): void {
-    this.atClick.emit();
+  public selectItem(event: MouseEvent): void {
+    this.atClick.emit(event);
     if (!this.selectable) {
       return;
     }

--- a/projects/ion/src/lib/sidebar/sidebar.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar.component.html
@@ -34,7 +34,7 @@
           [shrinkMode]="shrinkMode"
           [sidebarClosed]="closed"
           [attr.data-testid]="'ion-sidebar__item-' + i"
-          (atClick)="itemSelected(i)"
+          (atClick)="itemSelected(i, $event)"
         ></ion-sidebar-item>
       </ng-container>
       <ng-container *ngIf="item.options">
@@ -48,7 +48,7 @@
           [shrinkMode]="shrinkMode"
           [sidebarClosed]="closed"
           (atClick)="itemOnGroupSelected(i)"
-          (atGroupClick)="groupSelected(i)"
+          (atGroupClick)="groupSelected(i, $event)"
         ></ion-sidebar-group>
       </ng-container>
     </ng-container>

--- a/projects/ion/src/lib/sidebar/sidebar.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.component.ts
@@ -60,8 +60,8 @@ export class IonSidebarComponent implements AfterViewChecked {
     document.removeEventListener('click', this.checkClikOnPageAccess);
   }
 
-  public itemSelected(itemIndex: number): void {
-    selectItemByIndex(this.items, itemIndex);
+  public itemSelected(itemIndex: number, event: MouseEvent): void {
+    selectItemByIndex(this.items, itemIndex, event);
     if (this.closeOnSelect && !(this.shrinkMode && this.closed)) {
       this.toggleSidebarVisibility();
     }
@@ -74,9 +74,9 @@ export class IonSidebarComponent implements AfterViewChecked {
     }
   }
 
-  public groupSelected(groupIndex: number): void {
+  public groupSelected(groupIndex: number, event: MouseEvent): void {
     unselectAllItems(this.items);
-    callItemAction(this.items, groupIndex);
+    callItemAction(this.items, groupIndex, event);
   }
 
   public handleLogoClick(): void {

--- a/projects/ion/src/lib/sidebar/utils.ts
+++ b/projects/ion/src/lib/sidebar/utils.ts
@@ -4,9 +4,13 @@ function selectItem(items: Item[], index: number): void {
   items[index].selected = true;
 }
 
-export function callItemAction(items: Item[], index: number): void {
+export function callItemAction(
+  items: Item[],
+  index: number,
+  event: MouseEvent
+): void {
   if (items[index].action) {
-    items[index].action();
+    items[index].action(event);
   }
 }
 
@@ -20,9 +24,13 @@ export function unselectAllItems(
   });
 }
 
-export function selectItemByIndex(items: Item[], itemIndex: number): Item[] {
+export function selectItemByIndex(
+  items: Item[],
+  itemIndex: number,
+  event: MouseEvent
+): Item[] {
   unselectAllItems(items);
   selectItem(items, itemIndex);
-  callItemAction(items, itemIndex);
+  callItemAction(items, itemIndex, event);
   return items;
 }


### PR DESCRIPTION
#1279 

feat #1279 

## Description

Updates Sidebar Item and Sidebar Group components to emit the original MouseEvent up to the action handler.
This change allows the consumer application to check for modifier keys (like ctrlKey) to handle navigation strategies like opening in a new tab.

Changes:

Update Item interface to accept MouseEvent in action callback
Update sidebar-item to emit MouseEvent
Update sidebar-group to pass MouseEvent manually instead of using selectItemByIndex util

## Compliance

- [ ] I have verified that this change complies with our code and contribution policies.
- [ ] I have verified that this change does not cause regressions and does not affect other parts of the code.
