### PR TITLE
feat: support for multiple mouse button click in side bar #1305

### DIFF
--- a/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-group/sidebar-group.component.ts
@@ -6,8 +6,10 @@ import {
   Output,
   SimpleChanges,
 } from '@angular/core';
+
 import { IconType } from '../../core/types';
 import { Item } from '../../core/types/sidebar';
+import { MOUSE_BUTTONS } from '../../utils/mouse-buttons';
 import { selectItemByIndex, unselectAllItems } from '../utils';
 
 @Component({
@@ -43,7 +45,10 @@ export class IonSidebarGroupComponent implements OnChanges {
   }
 
   public itemSelected(itemIndex: number, event: MouseEvent): void {
-    this.selected = true;
+    if (event.button === MOUSE_BUTTONS.LEFT) {
+      this.selected = true;
+    }
+
     selectItemByIndex(this.items, itemIndex, event);
     this.atClick.emit(event);
   }

--- a/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.html
+++ b/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.html
@@ -8,7 +8,6 @@
   [class.ion-sidebar-item--shrunk]="shrinkMode && sidebarClosed"
   [class.ion-sidebar-subitem]="inGroup && sidebarClosed"
   [disabled]="disabled"
-  (click)="selectItem($event)"
 >
   <div>
     <ion-icon class="ion-sidebar-item__icon" [type]="icon"></ion-icon>

--- a/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.spec.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.spec.ts
@@ -1,9 +1,11 @@
-import { render, screen } from '@testing-library/angular';
+import { fireEvent, render, screen } from '@testing-library/angular';
 import userEvent from '@testing-library/user-event';
-import { IonTooltipModule } from './../../tooltip/tooltip.module';
+
 import { IonIconComponent } from '../../icon/icon.component';
-import { IonSidebarItemComponent } from './sidebar-item.component';
+import { MOUSE_BUTTONS } from '../../utils/mouse-buttons';
 import { SafeAny } from '../../utils/safe-any';
+import { IonTooltipModule } from './../../tooltip/tooltip.module';
+import { IonSidebarItemComponent } from './sidebar-item.component';
 
 const defaultTestId = 'ion-sidebar-item';
 const defaultClass = 'ion-sidebar-item';
@@ -55,6 +57,18 @@ describe('SidebarItem', () => {
     });
     const element = screen.getByTestId(defaultTestId);
     userEvent.click(element);
+    expect(element).not.toHaveClass(`${defaultClass}--selected`);
+  });
+  it('should select on mousedown with left button by default', async () => {
+    await sut();
+    const element = screen.getByTestId(defaultTestId);
+    fireEvent.mouseDown(element, { button: MOUSE_BUTTONS.LEFT });
+    expect(element).toHaveClass(`${defaultClass}--selected`);
+  });
+  it('should not select on mousedown when middle button is clicked', async () => {
+    await sut();
+    const element = screen.getByTestId(defaultTestId);
+    fireEvent.mouseDown(element, { button: MOUSE_BUTTONS.MIDDLE });
     expect(element).not.toHaveClass(`${defaultClass}--selected`);
   });
   it('should render disabled when prop is passed as true', async () => {

--- a/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar-item/sidebar-item.component.ts
@@ -1,5 +1,13 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import {
+  Component,
+  EventEmitter,
+  HostListener,
+  Input,
+  Output,
+} from '@angular/core';
+
 import { IconType } from '../../core/types';
+import { MOUSE_BUTTONS } from '../../utils/mouse-buttons';
 
 @Component({
   selector: 'ion-sidebar-item',
@@ -17,11 +25,22 @@ export class IonSidebarItemComponent {
   @Input() inGroup = false;
   @Output() atClick = new EventEmitter<MouseEvent>();
 
-  public selectItem(event: MouseEvent): void {
-    this.atClick.emit(event);
-    if (!this.selectable) {
-      return;
+  @HostListener('mousedown', ['$event'])
+  public onMouseDown(event: MouseEvent): void {
+    if (
+      event.button === MOUSE_BUTTONS.LEFT ||
+      event.button === MOUSE_BUTTONS.MIDDLE
+    ) {
+      if (event.button === MOUSE_BUTTONS.MIDDLE) {
+        event.preventDefault();
+        event.stopPropagation();
+      }
+
+      this.atClick.emit(event);
+
+      if (event.button === MOUSE_BUTTONS.LEFT && this.selectable) {
+        this.selected = true;
+      }
     }
-    this.selected = true;
   }
 }

--- a/projects/ion/src/lib/sidebar/sidebar.component.ts
+++ b/projects/ion/src/lib/sidebar/sidebar.component.ts
@@ -7,7 +7,9 @@ import {
   Output,
   TemplateRef,
 } from '@angular/core';
+
 import { IonSidebarProps } from '../core/types/sidebar';
+import { MOUSE_BUTTONS } from '../utils/mouse-buttons';
 import { callItemAction, selectItemByIndex, unselectAllItems } from './utils';
 
 @Component({
@@ -62,7 +64,11 @@ export class IonSidebarComponent implements AfterViewChecked {
 
   public itemSelected(itemIndex: number, event: MouseEvent): void {
     selectItemByIndex(this.items, itemIndex, event);
-    if (this.closeOnSelect && !(this.shrinkMode && this.closed)) {
+    if (
+      event.button !== MOUSE_BUTTONS.MIDDLE &&
+      this.closeOnSelect &&
+      !(this.shrinkMode && this.closed)
+    ) {
       this.toggleSidebarVisibility();
     }
   }

--- a/projects/ion/src/lib/sidebar/utils.ts
+++ b/projects/ion/src/lib/sidebar/utils.ts
@@ -1,4 +1,5 @@
 import { Item } from '../core/types';
+import { MOUSE_BUTTONS } from '../utils/mouse-buttons';
 
 function selectItem(items: Item[], index: number): void {
   items[index].selected = true;
@@ -29,6 +30,11 @@ export function selectItemByIndex(
   itemIndex: number,
   event: MouseEvent
 ): Item[] {
+  if (event && event.button === MOUSE_BUTTONS.MIDDLE) {
+    callItemAction(items, itemIndex, event);
+    return items;
+  }
+
   unselectAllItems(items);
   selectItem(items, itemIndex);
   callItemAction(items, itemIndex, event);

--- a/projects/ion/src/lib/utils/mouse-buttons.ts
+++ b/projects/ion/src/lib/utils/mouse-buttons.ts
@@ -1,0 +1,5 @@
+export const MOUSE_BUTTONS = {
+  LEFT: 0,
+  MIDDLE: 1,
+  RIGHT: 2,
+};


### PR DESCRIPTION
feat #1305 

## Description

This Pull Request introduces advanced navigation support for the Sidebar, allowing users to use the mouse middle button (scroll click) to open links in new tabs.

Why is this change necessary? Previously, the component relied solely on the standard (click) event, which is limited to the left mouse button. In productivity-focused workflows, users often need to open multiple sidebar modules in new tabs without losing their current context.

## Proposed Changes

**Sidebar Item Component**
- Replaced the (click) event binding in the template with @HostListener('mousedown') to reliably capture all button inputs in Angular 8 environments.
- Implemented logic to ignore the right mouse button, preventing accidental navigation triggers when opening context menus.
- Added event.preventDefault() and event.stopPropagation() specifically for the middle click to disable the browser's native "auto-scroll" feature.
- Protected the selected property: the item only updates its visual state if the click is performed with the left mouse button.

**Sidebar Component & Group**
- Updated itemSelected and groupSelected logic to respect the specific mouse button pressed.
- Ensured that the sidebar does not trigger toggleSidebarVisibility() (auto-closing) when an auxiliary button is detected.

**Utilities & Global**
- Created the MOUSE_BUTTONS constant object (LEFT: 0, MIDDLE: 1, RIGHT: 2) for standardization.

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
