### PR TITLE
ci: migrate to trusted publishers and session-based auth #1312

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
         node-version: [12.22.1]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: 🟢 node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org
@@ -34,7 +34,7 @@ jobs:
         run: npm publish --access public
         working-directory: dist/ion
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+          CI: true
 
       - name: Send message to Google Chat
         run: |


### PR DESCRIPTION
## #1312 

## Proposed Changes

- .github/workflows/release.yml

## References

https://docs.npmjs.com/trusted-publishers

