### PR TITLE
feat: add destroy event

### DIFF
--- a/projects/ion/package.json
+++ b/projects/ion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ion",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "peerDependencies": {
     "@angular/common": "^19.2.0",
     "@angular/core": "^19.2.0"

--- a/projects/ion/src/lib/core/bn-wizard/bn-wizard.types.ts
+++ b/projects/ion/src/lib/core/bn-wizard/bn-wizard.types.ts
@@ -21,4 +21,5 @@ export interface BnWizardConfig {
   isLoading?: boolean;
   onSubmit?: (data: any) => Observable<any> | Promise<any>;
   hiddenCancelButton?: boolean;
+  onDestroy?: () => void;
 }


### PR DESCRIPTION
Adiciona evento para indicar quando o wizard foi fechado sem concluir o preenchimento dos dados