### PR TITLE
ci: publisher using npm trusted publisher with OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: https://registry.npmjs.org
-          scope: "@brisanet"
 
       - name: 🚀 Publish
-        run: npm publish --access public --provenance
+        run: npm publish --provenance --access public
         working-directory: dist/ion
         env:
           CI: true
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
 
       - name: 📢 Send message to Google Chat
         run: |


### PR DESCRIPTION
## Description

This PR updates the release workflow to use npm's Trusted Publishing (OIDC) instead of token-based authentication. This improves security by eliminating the need for a long-lived NODE_AUTH_TOKEN secret.

## Proposed Changes

- Removed registry-url and scope configuration from actions/setup-node.
- Removed the NODE_AUTH_TOKEN environment variable usage.
- Updated the npm publish step to rely on OIDC authentication with provenance. 
- Modified: .github/workflows/release.yml

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.

## References

[npm Trusted Publishing Documentation](https://docs.npmjs.com/trusted-publishers#supported-cicd-providers)

