### PR TITLE
feat: adiciona ionOnClick no popover das tabelas

### DIFF
--- a/projects/ion/package.json
+++ b/projects/ion/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brisanet/ion",
-  "version": "21.1.7",
+  "version": "21.1.8",
   "repository": {
     "url": "https://github.com/Brisanet/ion"
   },
@@ -14,3 +14,4 @@
   },
   "sideEffects": false
 }
+  

--- a/projects/ion/src/lib/smart-table/smart-table.component.html
+++ b/projects/ion/src/lib/smart-table/smart-table.component.html
@@ -413,6 +413,14 @@
                                   )
                                 : null
                             "
+                            (ionOnClick)="
+                              action.popover!(row)['ionOnClick']
+                                ? handleEvent(
+                                    row,
+                                    action.popover!(row)['ionOnClick']
+                                  )
+                                : null
+                            "
                             [attr.data-testid]="
                               'row-' + index + '-' + action.label
                             "

--- a/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
+++ b/projects/ion/src/lib/smart-table/smart-table.component.spec.ts
@@ -1,3 +1,5 @@
+import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { render, screen, fireEvent } from '@testing-library/angular';
 import { IonSmartTableComponent } from './smart-table.component';
 import { ConfigSmartTable } from '../core/types';
@@ -25,6 +27,50 @@ const config: ConfigSmartTable<SafeAny> = {
   pagination,
   check: true,
 };
+
+@Component({
+  standalone: true,
+  imports: [CommonModule, IonSmartTableComponent],
+  template: `
+    <ng-template #popoverBody><span>popover-body</span></ng-template>
+    @if (viewReady) {
+      <ion-smart-table [config]="smartConfig" />
+    }
+  `,
+})
+class HostSmartTablePopoverHooksComponent implements OnInit {
+  @ViewChild('popoverBody', { static: true }) popoverBody!: TemplateRef<SafeAny>;
+
+  ionOnClick = jest.fn();
+
+  viewReady = false;
+
+  smartConfig!: ConfigSmartTable<SafeAny>;
+
+  ngOnInit(): void {
+    this.smartConfig = {
+      data: [{ id: 1, name: 'Item 1' }],
+      columns: [
+        { label: 'ID', key: 'id', sort: true },
+        { label: 'Name', key: 'name', sort: true },
+      ],
+      pagination: { total: 1, itemsPerPage: 10, page: 1 },
+      check: false,
+      actions: [
+        {
+          label: 'More',
+          icon: 'dots',
+          popover: () => ({
+            ionPopoverTitle: 'Title',
+            ionPopoverBody: this.popoverBody,
+            ionOnClick: (row: SafeAny) => this.ionOnClick(row),
+          }),
+        },
+      ],
+    };
+    this.viewReady = true;
+  }
+}
 
 describe('IonSmartTableComponent', () => {
   it('should render smart table', async () => {
@@ -88,5 +134,20 @@ describe('IonSmartTableComponent', () => {
 
     expect(emittedEvent).toBeTruthy();
     expect(emittedEvent.event).toBe('row_select');
+  });
+
+  it('should call ionOnClick from action.popover with row', async () => {
+    const { fixture } = await render(HostSmartTablePopoverHooksComponent);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const triggerHost = screen.getByTestId('row-0-More');
+    const innerButton = triggerHost.querySelector('button');
+    expect(innerButton).toBeTruthy();
+    fireEvent.click(innerButton!);
+
+    expect(host.ionOnClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 1, name: 'Item 1' }),
+    );
   });
 });

--- a/projects/ion/src/lib/table/ion-table.component.html
+++ b/projects/ion/src/lib/table/ion-table.component.html
@@ -312,6 +312,14 @@
                                 )
                               : null
                           "
+                          (ionOnClick)="
+                            action.popover!(row)['ionOnClick']
+                              ? handleEvent(
+                                  row,
+                                  action.popover!(row)['ionOnClick']
+                                )
+                              : null
+                          "
                           [attr.data-testid]="
                             'row-' + index + '-' + action.label
                           "

--- a/projects/ion/src/lib/table/ion-table.component.spec.ts
+++ b/projects/ion/src/lib/table/ion-table.component.spec.ts
@@ -1,3 +1,5 @@
+import { Component, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { fireEvent, render, screen } from '@testing-library/angular';
 import { IonTableComponent } from './ion-table.component';
 import { ConfigTable } from './utils';
@@ -42,6 +44,48 @@ const sut = async (
   });
 };
 
+@Component({
+  standalone: true,
+  imports: [CommonModule, IonTableComponent],
+  template: `
+    <ng-template #popoverBody><span>popover-body</span></ng-template>
+    @if (viewReady) {
+      <ion-table [config]="config" />
+    }
+  `,
+})
+class HostTablePopoverHooksComponent implements OnInit {
+  @ViewChild('popoverBody', { static: true }) popoverBody!: TemplateRef<SafeAny>;
+
+  ionOnClick = jest.fn();
+
+  viewReady = false;
+
+  config!: ConfigTable<SafeAny>;
+
+  ngOnInit(): void {
+    this.config = {
+      data: [{ col1: 'Data 1', col2: 'Data 2' }],
+      columns: [
+        { label: 'Column 1', key: 'col1' },
+        { label: 'Column 2', key: 'col2' },
+      ],
+      actions: [
+        {
+          label: 'More',
+          icon: 'dots',
+          popover: () => ({
+            ionPopoverTitle: 'Title',
+            ionPopoverBody: this.popoverBody,
+            ionOnClick: (row: SafeAny) => this.ionOnClick(row),
+          }),
+        },
+      ],
+    };
+    this.viewReady = true;
+  }
+}
+
 describe('IonTableComponent', () => {
   it('should render the table', async () => {
     await sut();
@@ -76,5 +120,21 @@ describe('IonTableComponent', () => {
       pagination: { total: 10, itemsPerPage: 5, page: 1 },
     });
     expect(screen.getByTestId('pagination-container')).toBeVisible();
+  });
+
+  it('should call ionOnClick from action.popover with row', async () => {
+    const { fixture } = await render(HostTablePopoverHooksComponent);
+    const host = fixture.componentInstance;
+    fixture.detectChanges();
+
+    const triggerHost = screen.getByTestId('row-0-More');
+    const innerButton = triggerHost.querySelector('button');
+    expect(innerButton).toBeTruthy();
+    fireEvent.click(innerButton!);
+
+    const expectedRow = { col1: 'Data 1', col2: 'Data 2' };
+    expect(host.ionOnClick).toHaveBeenCalledWith(
+      expect.objectContaining(expectedRow),
+    );
   });
 });

--- a/projects/ion/src/lib/table/utils.ts
+++ b/projects/ion/src/lib/table/utils.ts
@@ -85,7 +85,16 @@ export interface ActionConfirm<RowType> {
   cancelText?: string;
 }
 
-export type ActionPopover = SafeAny;
+/**
+ * Optional callback on the object returned by `action.popover(row)` (ion-table and smart-table).
+ */
+export interface ActionPopoverRowHooks<RowType = SafeAny> {
+  ionOnClick?: (row: RowType) => void;
+}
+
+/** Popover config per row; may include `ionOnClick` plus popover inputs. */
+export type ActionPopover<RowType = SafeAny> = SafeAny &
+  Partial<ActionPopoverRowHooks<RowType>>;
 
 export interface ActionTable<RowType = SafeAny> {
   label: string;
@@ -99,7 +108,7 @@ export interface ActionTable<RowType = SafeAny> {
   tooltipConfig?: TooltipProps;
   showLabel?: boolean;
   rightSideIcon?: boolean;
-  popover?: (row?: RowType) => ActionPopover;
+  popover?: (row?: RowType) => ActionPopover<RowType>;
 }
 
 export interface PaginationConfig {


### PR DESCRIPTION
Adiciona ações com popover nas tabelas passam a aceitar ionOnClick no retorno de popover(row) para receber a linha no clique do botão-gatilho, com testes e tipagem mínima do hook.

Necessário para disparar um evento ao clicar no botão que abre o popover nas tabelas.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, additive UI event hook and typing change for table action popovers, covered by new unit tests.
> 
> **Overview**
> Tables with `actions.popover(row)` now support an optional `ionOnClick(row)` hook that fires when the popover trigger button is clicked (implemented in both `ion-table` and `smart-table`).
> 
> This PR also tightens the `ActionPopover` typing to include the optional callback and adds unit tests validating the row is passed through, alongside a patch version bump to `21.1.8`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f95a6f40c45439a9ef78070956a50f0ce47693f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->